### PR TITLE
feat: add Apple Calendar import with EventKit integration

### DIFF
--- a/Tempo.xcodeproj/project.pbxproj
+++ b/Tempo.xcodeproj/project.pbxproj
@@ -50,6 +50,8 @@
 		000000000000000000000044 /* SettingsMenuView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 100000000000000000000044 /* SettingsMenuView.swift */; };
 		000000000000000000000045 /* NotificationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 100000000000000000000045 /* NotificationService.swift */; };
 		000000000000000000000046 /* RecurrenceFrequency.swift in Sources */ = {isa = PBXBuildFile; fileRef = 100000000000000000000046 /* RecurrenceFrequency.swift */; };
+		79B448AD2F48D9770092638B /* CalendarImportView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79B448AC2F48D9770092638B /* CalendarImportView.swift */; };
+		79B448B02F48DA520092638B /* CalendarService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79B448AE2F48DA1B0092638B /* CalendarService.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -98,6 +100,8 @@
 		100000000000000000000044 /* SettingsMenuView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsMenuView.swift; sourceTree = "<group>"; };
 		100000000000000000000045 /* NotificationService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationService.swift; sourceTree = "<group>"; };
 		100000000000000000000046 /* RecurrenceFrequency.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecurrenceFrequency.swift; sourceTree = "<group>"; };
+		79B448AC2F48D9770092638B /* CalendarImportView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendarImportView.swift; sourceTree = "<group>"; };
+		79B448AE2F48DA1B0092638B /* CalendarService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendarService.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -286,6 +290,7 @@
 				100000000000000000000036 /* SleepManager.swift */,
 				100000000000000000000042 /* CompensationTracker.swift */,
 				100000000000000000000045 /* NotificationService.swift */,
+				79B448AE2F48DA1B0092638B /* CalendarService.swift */,
 			);
 			path = Services;
 			sourceTree = "<group>";
@@ -295,6 +300,7 @@
 			children = (
 				100000000000000000000037 /* SleepSettingsView.swift */,
 				100000000000000000000044 /* SettingsMenuView.swift */,
+				79B448AC2F48D9770092638B /* CalendarImportView.swift */,
 			);
 			path = Settings;
 			sourceTree = "<group>";
@@ -391,6 +397,7 @@
 				000000000000000000000004 /* ScheduleItem.swift in Sources */,
 				000000000000000000000005 /* Change.swift in Sources */,
 				000000000000000000000006 /* ReshuffleResult.swift in Sources */,
+				79B448AD2F48D9770092638B /* CalendarImportView.swift in Sources */,
 				000000000000000000000007 /* EveningDecision.swift in Sources */,
 				000000000000000000000008 /* Constants.swift in Sources */,
 				000000000000000000000009 /* DateExtensions.swift in Sources */,
@@ -403,6 +410,7 @@
 				000000000000000000000016 /* FlexibleTaskProcessor.swift in Sources */,
 				000000000000000000000017 /* OptionalGoalProcessor.swift in Sources */,
 				000000000000000000000018 /* OverflowDetector.swift in Sources */,
+				79B448B02F48DA520092638B /* CalendarService.swift in Sources */,
 				000000000000000000000019 /* ReshuffleEngine.swift in Sources */,
 				000000000000000000000020 /* EveningProtectionAnalyzer.swift in Sources */,
 				000000000000000000000021 /* SummaryGenerator.swift in Sources */,

--- a/Tempo/Info.plist
+++ b/Tempo/Info.plist
@@ -2,7 +2,15 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+
 	<key>NSHealthShareUsageDescription</key>
 	<string>Tempo reads your sleep schedule to avoid scheduling tasks during your rest time.</string>
+
+	<key>NSCalendarsFullAccessUsageDescription</key>
+	<string>Tempo imports your Apple Calendar events as non-negotiable tasks to protect your commitments.</string>
+
+	<key>NSCalendarsUsageDescription</key>
+	<string>Tempo imports your Apple Calendar events as non-negotiable tasks to protect your commitments.</string>
+
 </dict>
 </plist>

--- a/Tempo/Services/CalendarService.swift
+++ b/Tempo/Services/CalendarService.swift
@@ -1,0 +1,34 @@
+import Foundation
+import EventKit
+
+protocol CalendarServiceProtocol {
+    func requestAccess() async throws -> Bool
+    func fetchCalendars() -> [EKCalendar]
+    func fetchEvents(from calendars: [EKCalendar],
+                     start: Date,
+                     end: Date) -> [EKEvent]
+}
+
+final class CalendarService: CalendarServiceProtocol {
+    
+    private let eventStore = EKEventStore()
+    
+    func requestAccess() async throws -> Bool {
+        return try await eventStore.requestFullAccessToEvents()
+    }
+    
+    func fetchCalendars() -> [EKCalendar] {
+        eventStore.calendars(for: .event)
+    }
+    
+    func fetchEvents(from calendars: [EKCalendar],
+                     start: Date,
+                     end: Date) -> [EKEvent] {
+        
+        let predicate = eventStore.predicateForEvents(withStart: start,
+                                                      end: end,
+                                                      calendars: calendars)
+        
+        return eventStore.events(matching: predicate)
+    }
+}

--- a/Tempo/Views/Settings/CalendarImportView.swift
+++ b/Tempo/Views/Settings/CalendarImportView.swift
@@ -1,0 +1,137 @@
+import SwiftUI
+import EventKit
+import SwiftData
+
+struct CalendarImportView: View {
+    
+    @Environment(\.modelContext) private var modelContext
+    
+    private let calendarService: CalendarServiceProtocol = CalendarService()
+    
+    @State private var calendars: [EKCalendar] = []
+    @State private var selectedCalendars: Set<String> = []
+    @State private var accessGranted = false
+    @State private var isLoading = false
+    @State private var showAlert = false
+    @State private var alertMessage = ""
+    
+    var body: some View {
+        List {
+            Section(header: Text("Permission")) {
+                Button("Request Calendar Access") {
+                    Task {
+                        await requestAccess()
+                    }
+                }
+            }
+            
+            if accessGranted {
+                Section(header: Text("Select Calendars")) {
+                    ForEach(calendars, id: \.calendarIdentifier) { calendar in
+                        Toggle(
+                            calendar.title,
+                            isOn: Binding(
+                                get: {
+                                    selectedCalendars.contains(calendar.calendarIdentifier)
+                                },
+                                set: { value in
+                                    if value {
+                                        selectedCalendars.insert(calendar.calendarIdentifier)
+                                    } else {
+                                        selectedCalendars.remove(calendar.calendarIdentifier)
+                                    }
+                                }
+                            )
+                        )
+                    }
+                }
+                
+                Section {
+                    Button {
+                        importEvents()
+                    } label: {
+                        if isLoading {
+                            ProgressView()
+                        } else {
+                            Text("Import Next 7 Days")
+                        }
+                    }
+                    .disabled(selectedCalendars.isEmpty || isLoading)
+                }
+            }
+        }
+        .navigationTitle("Calendar Import")
+        .alert("Calendar Import", isPresented: $showAlert) {
+            Button("OK", role: .cancel) { }
+        } message: {
+            Text(alertMessage)
+        }
+    }
+}
+
+// MARK: - Logic
+
+private extension CalendarImportView {
+    
+    func requestAccess() async {
+        do {
+            accessGranted = try await calendarService.requestAccess()
+            if accessGranted {
+                calendars = calendarService.fetchCalendars()
+            }
+        } catch {
+            alertMessage = "Failed to request calendar access."
+            showAlert = true
+        }
+    }
+    
+    func importEvents() {
+        guard accessGranted else { return }
+        
+        isLoading = true
+        
+        Task {
+            let selected = calendars.filter {
+                selectedCalendars.contains($0.calendarIdentifier)
+            }
+            
+            let startDate = Date()
+            let endDate = Calendar.current.date(byAdding: .day,
+                                                value: 7,
+                                                to: startDate) ?? startDate
+            
+            let events = calendarService.fetchEvents(
+                from: selected,
+                start: startDate,
+                end: endDate
+            )
+            
+            var importedCount = 0
+            
+            for event in events {
+                
+                let duration = Int(event.endDate.timeIntervalSince(event.startDate) / 60)
+                
+                let item = ScheduleItem(
+                    title: event.title ?? "Untitled Event",
+                    category: .nonNegotiable, startTime: event.startDate,
+                    durationMinutes: max(duration, 1),
+                    notes: "Imported from Apple Calendar"
+                )
+                
+                modelContext.insert(item)
+                importedCount += 1
+            }
+            
+            do {
+                try modelContext.save()
+            } catch {
+                print("Failed to save imported events:", error)
+            }
+            
+            isLoading = false
+            alertMessage = "Imported \(importedCount) events."
+            showAlert = true
+        }
+    }
+}

--- a/Tempo/Views/Settings/SettingsMenuView.swift
+++ b/Tempo/Views/Settings/SettingsMenuView.swift
@@ -8,7 +8,9 @@ struct SettingsMenuView: View {
 
     var body: some View {
         List {
-            // Sleep Schedule Section
+            
+            // MARK: - Time Blocking
+            
             Section {
                 NavigationLink {
                     SleepSettingsView(sleepManager: sleepManager)
@@ -37,8 +39,34 @@ struct SettingsMenuView: View {
             } header: {
                 Text("Time Blocking")
             }
+            
+            // MARK: - Calendar
+            
+            Section {
+                NavigationLink {
+                    CalendarImportView()
+                } label: {
+                    HStack(spacing: 12) {
+                        Image(systemName: "calendar.badge.plus")
+                            .foregroundColor(.blue)
+                            .frame(width: 28)
 
-            // Compensation Section
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text("Import Apple Calendar")
+                                .font(.body)
+                            
+                            Text("Sync events as Non-Negotiable tasks")
+                                .font(.caption)
+                                .foregroundColor(.secondary)
+                        }
+                    }
+                }
+            } header: {
+                Text("Calendar")
+            }
+            
+            // MARK: - Task Management
+            
             Section {
                 NavigationLink {
                     CompensationView(compensationTracker: compensationTracker)
@@ -68,7 +96,8 @@ struct SettingsMenuView: View {
                 Text("Task Management")
             }
 
-            // About Section
+            // MARK: - About
+            
             Section {
                 HStack {
                     Text("Version")


### PR DESCRIPTION
Adds Apple Calendar import using EventKit.

Requests calendar access

Lets users select calendars

Imports next 7 days of events

Maps events to Non-Negotiable ScheduleItems

Integrated with existing ScheduleViewModel

Tested on simulator.