### PR TITLE
feat: export daily schedule as shareable image via ImageRenderer

### DIFF
--- a/Tempo/Services/ScheduleExportService.swift
+++ b/Tempo/Services/ScheduleExportService.swift
@@ -1,0 +1,42 @@
+import SwiftUI
+
+@MainActor
+final class ScheduleExportService {
+    static let shared = ScheduleExportService()
+    private init() {}
+
+
+    func renderImage(date: Date, items: [ScheduleItem]) -> UIImage? {
+        let view = ScheduleExportView(date: date, items: items)
+            .frame(width: 390) 
+            .environment(\.colorScheme, .light) 
+
+        let renderer = ImageRenderer(content: view)
+        renderer.scale = 3.0 
+        return renderer.uiImage
+    }
+
+   
+    func exportAndShare(date: Date, items: [ScheduleItem], presenting sourceView: UIView? = nil) {
+        guard let image = renderImage(date: date, items: items) else { return }
+
+        let activityVC = UIActivityViewController(
+            activityItems: [image],
+            applicationActivities: nil
+        )
+
+     
+        if let popover = activityVC.popoverPresentationController {
+            popover.sourceView = sourceView ?? UIApplication.shared.connectedScenes
+                .compactMap { $0 as? UIWindowScene }
+                .first?.windows.first
+            popover.sourceRect = CGRect(x: UIScreen.main.bounds.midX, y: UIScreen.main.bounds.midY, width: 0, height: 0)
+            popover.permittedArrowDirections = []
+        }
+
+        UIApplication.shared.connectedScenes
+            .compactMap { $0 as? UIWindowScene }
+            .first?.windows.first?.rootViewController?
+            .present(activityVC, animated: true)
+    }
+}

--- a/Tempo/Views/Schedule/ScheduleExportView.swift
+++ b/Tempo/Views/Schedule/ScheduleExportView.swift
@@ -1,0 +1,145 @@
+import SwiftUI
+
+struct ScheduleExportView: View {
+    let date: Date
+    let items: [ScheduleItem]
+
+    private var dateString: String {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "EEEE, MMM d"
+        return formatter.string(from: date)
+    }
+
+    private var completedCount: Int {
+        items.filter { $0.isCompleted }.count
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+
+            // Header
+            VStack(alignment: .leading, spacing: 6) {
+                HStack {
+                    Text("Tempo")
+                        .font(.caption)
+                        .fontWeight(.semibold)
+                        .foregroundStyle(.secondary)
+                    Spacer()
+                    Text("\(completedCount)/\(items.count) done")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+
+                Text(dateString)
+                    .font(.title2)
+                    .fontWeight(.bold)
+
+                // Progress bar
+                GeometryReader { geo in
+                    ZStack(alignment: .leading) {
+                        RoundedRectangle(cornerRadius: 3)
+                            .fill(Color(.systemGray5))
+                            .frame(height: 6)
+                        RoundedRectangle(cornerRadius: 3)
+                            .fill(Color.green)
+                            .frame(
+                                width: items.isEmpty ? 0 : geo.size.width * CGFloat(completedCount) / CGFloat(items.count),
+                                height: 6
+                            )
+                    }
+                }
+                .frame(height: 6)
+            }
+            .padding(.horizontal, 20)
+            .padding(.vertical, 18)
+            .background(Color(.systemBackground))
+
+            Divider()
+
+            // Task list
+            if items.isEmpty {
+                Text("No tasks scheduled")
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+                    .frame(maxWidth: .infinity)
+                    .padding(40)
+            } else {
+                VStack(spacing: 0) {
+                    ForEach(items.sorted { $0.startTime < $1.startTime }) { item in
+                        exportTaskRow(item)
+                        if item.id != items.sorted(by: { $0.startTime < $1.startTime }).last?.id {
+                            Divider()
+                                .padding(.leading, 56)
+                        }
+                    }
+                }
+            }
+
+            // Footer
+            Divider()
+            HStack {
+                Spacer()
+                Text("Made with Tempo")
+                    .font(.caption2)
+                    .foregroundStyle(Color(.systemGray3))
+            }
+            .padding(.horizontal, 20)
+            .padding(.vertical, 10)
+            .background(Color(.systemBackground))
+        }
+        .background(Color(.systemGroupedBackground))
+        .clipShape(RoundedRectangle(cornerRadius: 20))
+    }
+
+    private func exportTaskRow(_ item: ScheduleItem) -> some View {
+        HStack(spacing: 12) {
+            // Category color dot + icon
+            ZStack {
+                Circle()
+                    .fill(item.category.color.opacity(0.15))
+                    .frame(width: 36, height: 36)
+                Image(systemName: item.category.iconName)
+                    .font(.system(size: 14))
+                    .foregroundStyle(item.category.color)
+            }
+
+            // Task info
+            VStack(alignment: .leading, spacing: 2) {
+                Text(item.title)
+                    .font(.subheadline)
+                    .fontWeight(.medium)
+                    .foregroundStyle(item.isCompleted ? .secondary : .primary)
+                    .strikethrough(item.isCompleted)
+
+                Text(formatTimeRange(item))
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+
+            Spacer()
+
+            // Duration badge
+            Text("\(item.durationMinutes) min")
+                .font(.caption2)
+                .foregroundStyle(.secondary)
+                .padding(.horizontal, 8)
+                .padding(.vertical, 4)
+                .background(Color(.systemGray6))
+                .clipShape(Capsule())
+
+            // Completion indicator
+            Image(systemName: item.isCompleted ? "checkmark.circle.fill" : "circle")
+                .foregroundStyle(item.isCompleted ? Color.green : Color(.systemGray4))
+                .font(.system(size: 18))
+        }
+        .padding(.horizontal, 20)
+        .padding(.vertical, 12)
+        .background(Color(.systemBackground))
+    }
+
+    private func formatTimeRange(_ item: ScheduleItem) -> String {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "h:mm a"
+        return "\(formatter.string(from: item.startTime)) – \(formatter.string(from: item.endTime))"
+    }
+}

--- a/Tempo/Views/Schedule/ScheduleSharePreviewSheet.swift
+++ b/Tempo/Views/Schedule/ScheduleSharePreviewSheet.swift
@@ -1,0 +1,50 @@
+import SwiftUI
+
+struct ScheduleSharePreviewSheet: View {
+    let date: Date
+    let items: [ScheduleItem]
+
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        NavigationStack {
+            ScrollView {
+                VStack(spacing: 24) {
+                    Text("Preview")
+                        .font(.subheadline)
+                        .foregroundStyle(.secondary)
+
+                 
+                    ScheduleExportView(date: date, items: items)
+                        .frame(maxWidth: 390)
+                        .shadow(color: .black.opacity(0.1), radius: 16, x: 0, y: 8)
+                        .padding(.horizontal, 24)
+
+         
+                    Button(action: {
+                        ScheduleExportService.shared.exportAndShare(date: date, items: items)
+                    }) {
+                        Label("Share Schedule", systemImage: "square.and.arrow.up")
+                            .font(.subheadline)
+                            .fontWeight(.semibold)
+                            .foregroundStyle(.white)
+                            .frame(maxWidth: .infinity)
+                            .padding(.vertical, 16)
+                            .background(Color.accentColor)
+                            .clipShape(RoundedRectangle(cornerRadius: 14))
+                    }
+                    .padding(.horizontal, 24)
+                }
+                .padding(.vertical, 24)
+            }
+            .background(Color(.systemGroupedBackground))
+            .navigationTitle("Export Schedule")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") { dismiss() }
+                }
+            }
+        }
+    }
+}

--- a/Tempo/Views/Schedule/ScheduleView.swift
+++ b/Tempo/Views/Schedule/ScheduleView.swift
@@ -9,6 +9,8 @@ struct ConflictResolutionData: Identifiable {
 
 /// Main daily schedule view - Structured-inspired timeline design.
 struct ScheduleView: View {
+
+    @State private var showingExportPreview = false
     @Environment(\.modelContext) private var modelContext
     @EnvironmentObject private var sleepManager: SleepManager
     @Binding var selectedDate: Date
@@ -178,16 +180,25 @@ struct ScheduleView: View {
             }
 
             ToolbarItem(placement: .topBarTrailing) {
+                // Export / share button
+                Button(action: {
+                    showingExportPreview = true
+                }) {
+                    Image(systemName: "square.and.arrow.up")
+                }
+            }
+
+            ToolbarItem(placement: .topBarTrailing) {
                 Button(action: {
                     selectedSlotTime = nil
                     onAddTask()
                 }) {
                    Image(systemName: "plus")
-    .font(.title3)
-    .foregroundStyle(.white)
-    .frame(width: 32, height: 32)
-    .background(Color.accentColor)
-    .clipShape(Circle())
+                    .font(.title3)
+                    .foregroundStyle(.white)
+                    .frame(width: 32, height: 32)
+                    .background(Color.accentColor)
+                    .clipShape(Circle())
                 }
             }
         }
@@ -277,6 +288,15 @@ struct ScheduleView: View {
             .presentationDetents([.height(280)])
             .presentationDragIndicator(.visible)
         }
+        // Export preview sheet
+        .sheet(isPresented: $showingExportPreview) {
+            ScheduleSharePreviewSheet(
+                date: selectedDate,
+                items: itemsForSelectedDate
+            )
+            .presentationDetents([.large])
+            .presentationDragIndicator(.visible)
+        }
     }
 
     // MARK: - Week Calendar Header
@@ -291,7 +311,7 @@ struct ScheduleView: View {
                 Text((currentWeekDays.last ?? selectedDate).formatted(.dateTime.year()))
                     .font(.title2)
                     .fontWeight(.bold)
-.foregroundStyle(Color.accentColor)
+                    .foregroundStyle(Color.accentColor)
 
                 Spacer()
 
@@ -1430,7 +1450,7 @@ struct ConflictResolutionSheet: View {
         .padding()
         .background(Color(.systemBackground))
         .cornerRadius(16)
-       .shadow(color: Color.primary.opacity(0.08), radius: 8, x: 0, y: 2)
+        .shadow(color: Color.primary.opacity(0.08), radius: 8, x: 0, y: 2)
     }
 }
 


### PR DESCRIPTION
Closes #8

## What's changed
Lets users export their daily schedule as a clean, shareable image using SwiftUI's ImageRenderer.

## How it works
- Tap the share icon (↑) in the top-right of the schedule view
- A preview sheet opens showing exactly what will be shared
- Tap "Share Schedule" to bring up the iOS share sheet (save to photos, send via Messages, post to social media, etc.)
- The exported image is always in light mode for clean, readable sharing
- Rendered at 3x resolution for crisp quality on all screens

## New files
- `Tempo/Views/Schedule/ScheduleExportView.swift` - clean snapshot view rendered by ImageRenderer
- `Tempo/Views/Schedule/ScheduleSharePreviewSheet.swift` - preview sheet shown before sharing
- `Tempo/Services/ScheduleExportService.swift` - handles ImageRenderer rendering and UIActivityViewController presentation

## Modified files
- `Tempo/Views/Schedule/ScheduleView.swift` - adds share toolbar button and export sheet
```